### PR TITLE
Add GPU support, fix arousal leak/path bug, refactor stage for model reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,140 @@ For each input data file, CAISR generates the following output:
 ### 5. **Cleanup (Optional)**
 You can optionally clean up Docker images and containers after running the tasks. This will require reloading/rebuilding the Docker images for future runs.
 
+## Running on GPU
+
+Each module's Conda env ships without bundled CUDA libraries. If you want GPU acceleration, install matched CUDA + cuDNN into the env. The cluster's *driver* is forward-compatible, so you can run TF compiled against an older CUDA toolkit on a newer driver — but TF's bundled cuBLAS only has kernels for the GPU compute capabilities it was built against.
+
+| Env | TF version | Required CUDA / cuDNN | Compatible GPU compute |
+| :--- | :--- | :--- | :--- |
+| `caisr_stage` | 1.15.0 (Py 3.6) | `cudatoolkit=10.0` + `cudnn=7.6` | sm_60 (Pascal), **sm_70 (Volta — V100)**, sm_75 (Turing — RTX 20-series, T4) |
+| `caisr_arousal` | 2.8.0 | `cudatoolkit=11.2` + `cudnn=8.1.0` | sm_60–sm_75 *and* sm_80/86/89 (Ampere, Ada — A100, A30, RTX 30/40-series, RTX 6000 Ada) |
+
+`caisr_resp` and `caisr_limb` are rule-based (scipy/numpy) and **do not benefit from a GPU**.
+
+### One-time CUDA install
+
+Install matching CUDA libs into a *clone* of each env (so you can keep CPU-only envs around for non-GPU runs):
+
+```bash
+# Stage — TF 1.15 → only Volta/Turing/Pascal
+conda create -n caisr_stage_gpu --clone caisr_stage
+conda activate caisr_stage_gpu
+conda install -c conda-forge cudatoolkit=10.0 cudnn=7.6
+conda deactivate
+
+# Arousal — TF 2.8 → works on all modern GPUs
+conda create -n caisr_arousal_gpu --clone caisr_arousal
+conda activate caisr_arousal_gpu
+conda install -c conda-forge cudatoolkit=11.2 cudnn=8.1.0
+conda deactivate
+```
+
+At runtime, point TF at the env-local CUDA libs:
+
+```bash
+export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
+```
+
+To verify a GPU is visible to TF:
+
+```bash
+python -c "import tensorflow as tf; print(tf.config.list_physical_devices('GPU'))"
+```
+
+If you see `[]`, the env's CUDA libraries don't match your GPU's compute capability — for stage on Ampere/Ada, you'll see `Blas GEMM launch failed` (cuBLAS sm_70 only).
+
+### Stage performance tip
+
+`caisr_stage.py`'s sequential path **builds the TF model once** and reuses it across subjects (saves ~30 s/subject of rebuild + weight reload). On a V100 you should see ~25–50 s/subject steady-state — most of that is CPU-side feature extraction (DE/PSD), not GPU compute.
+
+### Arousal memory stability
+
+`caisr_arousal.py:predict()` calls `tf.keras.backend.clear_session()` at the start of each subject to reset the default TF graph. Without it, model rebuilds accumulate graph nodes across subjects and OOM long-running tasks (~32 GB at ~300 sequential subjects).
+
+## Running at scale with SLURM job arrays
+
+For large cohorts (10k+ recordings), a single sbatch is too slow. Use a job array that slices the input directory across N tasks, each handling subjects whose index-mod-N equals its `SLURM_ARRAY_TASK_ID`. Outputs go to one shared directory; `overwrite=False` makes re-runs idempotent.
+
+### Stage — GPU array (TF 1.15 needs Volta/Turing)
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=stg_array
+#SBATCH --partition=overflow            # Volta is in overflow on this cluster
+#SBATCH --gres=gpu:1
+#SBATCH --constraint=cuda10             # restrict to nodes with the CUDA-10 feature
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=24G
+#SBATCH --time=24:00:00
+#SBATCH --array=0-49
+
+set -euo pipefail
+TASK_ID=$SLURM_ARRAY_TASK_ID
+NTASKS=${SLURM_ARRAY_TASK_COUNT:-50}
+
+REPO=/path/to/CAISR-App
+IN=/path/to/cohort/h5
+OUT=/path/to/output
+SLICE=/scratch/$USER/slices/stg/task_${TASK_ID}
+
+source $(conda info --base)/etc/profile.d/conda.sh
+conda activate caisr_stage_gpu
+export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
+
+# Build per-task input slice via symlinks
+rm -rf "$SLICE" && mkdir -p "$SLICE"
+i=0
+for h5 in "$IN"/*.h5; do
+  if [ $((i % NTASKS)) -eq "$TASK_ID" ]; then
+    ln -sfn "$h5" "$SLICE/$(basename "$h5")"
+  fi
+  i=$((i+1))
+done
+
+cd "$REPO"
+python caisr_stage.py \
+  --input_data_dir "$SLICE" \
+  --output_csv_dir "$OUT" \
+  --model_dir      "$REPO/stage/models" \
+  --param_dir      "$REPO/data/run_parameters"
+
+rm -rf "$SLICE"
+```
+
+### Arousal — GPU array (works on Ampere/Ada too)
+
+Same template, but use `caisr_arousal_gpu`, replace `caisr_stage.py` with `caisr_arousal.py`, drop `--model_dir`, and bump `--mem=64G`. If your partition has Ampere/Ada GPUs, drop `--constraint=cuda10`.
+
+### Limb / Resp — CPU sbatch (single node)
+
+Limb and resp are rule-based; submit one CPU sbatch per cohort with `multiprocess=True` (resp uses Ray, limb uses a worker count). No array needed.
+
+### Important: set `multiprocess=False` for GPU array tasks
+
+Each array task gets one GPU. With `multiprocess=True`, the script would spawn many CPU workers, each loading its own TF model into the same GPU — they'd OOM the GPU. Always flip the relevant `data/run_parameters/<task>.csv` to `multiprocess=False` before submitting a GPU array.
+
+### Chaining the full pipeline with dependencies
+
+```bash
+# Stage first
+STG=$(sbatch --parsable stage_array.sbatch)
+# Arousal once stage finishes
+ARO=$(sbatch --parsable --dependency=afterany:$STG arousal_array.sbatch)
+# A second arousal pass to catch subjects whose stage CSV arrived late
+ARO2=$(sbatch --parsable --dependency=afterany:$ARO arousal_array.sbatch)
+# Resp once arousal is fully done (resp loads stage_CAISR + arousal_CAISR per subject)
+RSP=$(sbatch --parsable --dependency=afterany:$ARO2 resp.sbatch)
+# Limb is independent of stage/arousal — fire it in parallel with the chain above
+LMB=$(sbatch --parsable limb.sbatch)
+# Combine after both resp and limb finish
+sbatch --dependency=afterany:$RSP,afterany:$LMB combine.sbatch
+```
+
+### Why two arousal passes?
+
+When stage and arousal arrays run in parallel, an arousal task may pass over a subject whose stage CSV hasn't been written yet — the script logs `No stage file found, skipping`. A second arousal pass with `overwrite=False` picks up only those late-stagers and processes them.
+
 ## Notes
 - **Error Handling**: The script includes basic error handling. If a Docker image cannot be found or loaded, the script will exit with an error message.
 - **Modularity**: You can customize the tasks and their order by modifying the `tasks` list in the script.

--- a/caisr_arousal.py
+++ b/caisr_arousal.py
@@ -177,7 +177,8 @@ def set_output_paths(
     filtered input paths, filtered csv paths
     """
     ids = [p.split("/")[-1].split(".")[0] for p in input_paths]
-    csv_paths = [f"{csv_folder}arousal/{id_}_arousal.csv" for id_ in ids]
+    csv_paths = [os.path.join(csv_folder, "arousal", f"{id_}_arousal.csv") for id_ in ids]
+    os.makedirs(os.path.join(csv_folder, "arousal"), exist_ok=True)
     assert len(input_paths) == len(csv_paths), (
         "SETUP ERROR: mismatch between input file count and CSV path count."
     )
@@ -635,6 +636,7 @@ def pre_process_temporal_scaling(
     ]
 
     # --- Load raw signals (H5 or EDF, auto-detected) ---
+    _unit_attr = None
     if file.lower().endswith('.edf'):
         sig_group = _load_arousal_edf_as_sig_group(file, target_fs=200)
     else:
@@ -653,6 +655,14 @@ def pre_process_temporal_scaling(
                 # Materialise to a dict so the h5 file handle can close cleanly.
                 _src = f["signals"] if "signals" in f else f
                 sig_group = {k: np.array(_src[k]) for k in _src.keys()}
+            # Capture voltage-unit hint (e.g. f.attrs['unit_voltage'] = 'V'|'uV').
+            _ua = f.attrs.get("unit_voltage", None)
+            if _ua is not None:
+                try:
+                    _ua = _ua.decode() if isinstance(_ua, bytes) else _ua
+                    _unit_attr = str(_ua).strip().lower().replace("μ", "u")
+                except Exception:
+                    _unit_attr = None
 
     available = set(sig_group.keys())
     missing_idx = [i for i, ch in enumerate(channels) if ch not in available]
@@ -701,6 +711,23 @@ def pre_process_temporal_scaling(
     for i, ch in enumerate(channels):
         src = substitute_map.get(ch, ch)
         data[i, :] = np.squeeze(np.array(sig_group[src]))
+
+    # --- Auto-detect input voltage scale (V vs uV) and convert to V ---
+    # Trust f.attrs['unit_voltage'] if present; otherwise use amplitude.
+    # qli-prepared data is clipped to ~±20 dimensionless, raw V EEG is
+    # ~±1e-3 V, raw uV EEG ranges up to ~±300 uV — so a 99th-percentile
+    # threshold of 30 separates uV from {qli, V} cleanly.
+    VOLTAGE_TYPES = {"EEG", "EYE", "CHIN", "ECG", "CHIN_RAW"}
+    voltage_idxs = [i for i, ct in enumerate(channel_type) if ct in VOLTAGE_TYPES]
+    input_in_uV = False
+    if _unit_attr in ("uv", "microvolt", "microvolts"):
+        input_in_uV = True
+    elif _unit_attr not in ("v", "volt", "volts") and voltage_idxs:
+        sample_p99 = float(np.nanpercentile(np.abs(data[voltage_idxs[0], :]), 99))
+        input_in_uV = sample_p99 > 30
+    if input_in_uV:
+        for i in voltage_idxs:
+            data[i, :] = data[i, :] / 1e6
 
     # --- Detect pre-normalised (qli) vs raw (EDF/HSP) data ---
     # JMLR qli-prepared H5 files are clipped and RobustScaler-normalised to
@@ -803,6 +830,12 @@ def predict(
     DataFrame with columns:
         start_idx, end_idx, arousal, prob_no, prob_arousal, pp_trace
     """
+    # Reset the default TF graph each call. Without this, every model rebuild
+    # adds nodes to the previous graph, accumulating memory across subjects
+    # and OOMing tasks that process more than ~300 sequential files (observed
+    # at ~32 GB).
+    tf.keras.backend.clear_session()
+    import gc; gc.collect()
     hparams = YAMLHParams(HPARAMS_PATH)
     INPUT_HZ = 128
     OUTPUT_HZ = 2
@@ -973,9 +1006,15 @@ def process_single_arousal_file(
             pd.read_csv(hypno_path)["stage"].fillna(5).values.repeat(128)
         )
 
-        # Always run in 2-channel mode (C3-M2 / C4-M1 preferred, fallback applied above)
+        # 6-channel default (frontal+central+occipital); fall back to
+        # 2-channel (C3/C4 only) when frontal/occipital are missing or
+        # otherwise cause predict() to fail.
         with h5.File(temp_h5_path, "r") as hf:
-            df = predict(hf, model_path, channels, hypnogram, EEG_chan=2)
+            try:
+                df = predict(hf, model_path, channels, hypnogram, EEG_chan=6)
+            except Exception as exc6:
+                print(f"  -> 6-chn predict failed for '{display_id}': {exc6}. Falling back to 2-chn.", flush=True)
+                df = predict(hf, model_path, channels, hypnogram, EEG_chan=2)
 
         df.to_csv(write_path, index=False)
 
@@ -1012,14 +1051,16 @@ def CAISR_arousal(
     multiprocess  : bool         If True, use ``multiprocessing.Pool``.
     """
     # PSG channels used for model input (order must match channel_type).
-    # Central EEG (C3-M2, C4-M1) preferred; fallback chain in
-    # pre_process_temporal_scaling handles substitution when absent.
+    # Default = 6-EEG (frontal+central+occipital); pre_process_temporal_scaling
+    # drops F3/F4/O1/O2 when missing (no substitution), so predict() with
+    # EEG_chan=6 will fail-fast and process_single_arousal_file falls back to
+    # EEG_chan=2 using C3-M2 / C4-M1.
     channels = [
-        "c3-m2", "c4-m1",
+        "f3-m2", "f4-m1", "c3-m2", "c4-m1", "o1-m2", "o2-m1",
         "e1-m2", "chin1-chin2", "ecg", "chin1-chin2",
     ]
     channel_type = [
-        "EEG", "EEG",
+        "EEG", "EEG", "EEG", "EEG", "EEG", "EEG",
         "EYE", "CHIN", "ECG", "CHIN_RAW",
     ]
     temporal_resolution = 5  # minutes

--- a/caisr_limb.py
+++ b/caisr_limb.py
@@ -18,11 +18,42 @@ import time
 import argparse
 import multiprocessing
 from math import gcd
+import h5py
 import numpy as np
 import pandas as pd
 from scipy import signal
 from scipy.signal import resample_poly
 from typing import List, Tuple
+
+
+def _input_is_microvolt(path: str, sample: np.ndarray) -> bool:
+    """
+    Decide whether a CAISR input is stored in microvolts (vs volts).
+    Trust ``f.attrs['unit_voltage']`` when present (H5 only); otherwise
+    fall back to amplitude — EMG in V has 99th-pct |x| ~ 1e-5–1e-4,
+    EMG in uV ~ 10–100. EDF inputs go through the EDF loader which
+    returns Volts, so the amplitude path correctly classifies them.
+    """
+    unit = None
+    if path.lower().endswith('.h5'):
+        try:
+            with h5py.File(path, "r") as f:
+                unit = f.attrs.get("unit_voltage", None)
+        except Exception:
+            unit = None
+    if unit is not None:
+        try:
+            unit = unit.decode() if isinstance(unit, bytes) else unit
+            unit = str(unit).strip().lower().replace("μ", "u")
+        except Exception:
+            unit = None
+    if unit in ("uv", "microvolt", "microvolts"):
+        return True
+    if unit in ("v", "volt", "volts"):
+        return False
+    p99 = float(np.nanpercentile(np.abs(np.asarray(sample)), 99))
+    return p99 > 0.5
+
 
 sys.path.insert(1, './limb')
 from utils_limb import *
@@ -161,7 +192,9 @@ def process_single_limb_file(path: str, save_path: str, file_info: Tuple[int, in
         print(f'ERROR loading signals for "{the_id}": {e}')
         return
     
-    signal_emg = np.array(emg_signal_resampled.T) * 1e6
+    signal_emg = np.array(emg_signal_resampled.T)
+    if not _input_is_microvolt(path, signal_emg):
+        signal_emg = signal_emg * 1e6
     sample_rate = 100
 
     lower_threshold_uV = 2

--- a/caisr_stage.py
+++ b/caisr_stage.py
@@ -188,35 +188,42 @@ def filter_already_processed_files(input_paths: 'list[str]', csv_paths: 'list[st
     return input_paths, csv_paths
 
 
-def process_single_file(path: str, save_path: str, model_path: str, model_params: dict, file_info: 'tuple[int, int]'):
-    """
-    Processes a single input file for sleep staging.
-    Loads its own model instance to ensure thread/process safety.
-    """
-    num, total = file_info
-    
-    # Unpack parameters
-    opt = model_params['optimizer']
-    regularizer = model_params['regularizer']
-    w, h, context = model_params['w'], model_params['h'], model_params['context']
-    sample_shape = (context, w, h)
-    
-    # Build model
+def _build_stage_model(model_path: str, model_params: dict):
+    """Build ProductGraphSleepNet and load fold-3 weights."""
+    sample_shape = (model_params['context'], model_params['w'], model_params['h'])
     model = build_ProductGraphSleepNet(
-        model_params['cheb_k'], model_params['num_of_chev_filters'], model_params['num_of_time_filters'], 
+        model_params['cheb_k'], model_params['num_of_chev_filters'], model_params['num_of_time_filters'],
         model_params['time_conv_strides'], model_params['cheb_polynomials'],
-        model_params['time_conv_kernel'], sample_shape, model_params['num_block'], opt, 
-        model_params['conf_adj'] == 'GL', model_params['GLalpha'], regularizer,
-        model_params['GRU_Cell'], model_params['attn_heads'], model_params['dropout']
+        model_params['time_conv_kernel'], sample_shape, model_params['num_block'],
+        model_params['optimizer'],
+        model_params['conf_adj'] == 'GL', model_params['GLalpha'], model_params['regularizer'],
+        model_params['GRU_Cell'], model_params['attn_heads'], model_params['dropout'],
     )
-    
     weights_file = os.path.join(model_path, 'weights_fold_3.h5')
     if not os.path.exists(weights_file):
-        print(f"Error: Weights file not found at {weights_file}")
-        return
-
+        raise FileNotFoundError(f"Weights file not found at {weights_file}")
     model.load_weights(weights_file)
-    
+    return model
+
+
+def process_single_file(path: str, save_path: str, model_path: str, model_params: dict, file_info: 'tuple[int, int]', model=None):
+    """
+    Processes a single input file for sleep staging.
+    Builds its own model when ``model`` is None (multiprocess workers); otherwise
+    reuses the caller's pre-built TF model — saves ~30 s per subject in the
+    sequential path by skipping rebuild + weight reload.
+    """
+    num, total = file_info
+
+    if model is None:
+        try:
+            model = _build_stage_model(model_path, model_params)
+        except FileNotFoundError as exc:
+            print(f"Error: {exc}")
+            return
+
+    context = model_params['context']
+
     the_id = path.split(os.sep)[-1].split('.')[0]
     tag = the_id if len(the_id) < 21 else the_id[:20] + '..'
     print(f'(# {num + 1}/{total}) Processing "{tag}" [PID:{os.getpid()}]')
@@ -308,22 +315,31 @@ def CAISR_stage(in_paths: 'list[str]', save_paths: 'list[str]', model_path: str,
 
     # --- Dispatch jobs ---
     if multiprocess and len(in_paths) > 1:
-        # Use available CPUs, cap at 24 to prevent OOM if model is heavy
-        num_workers = min(24, multiprocessing.cpu_count())
+        # Cap at 12 (24 OOMed at ~900 GB on a single node; each TF worker holds ~10 GB).
+        # maxtasksperchild recycles worker procs to release accumulated TF state.
+        num_workers = min(12, multiprocessing.cpu_count())
         print(f">> Multiprocessing enabled. Starting parallel processing with {num_workers} workers...")
-        
+
         tasks = [
             (path, save_path, model_path, model_params, (num, len(in_paths)))
             for num, (path, save_path) in enumerate(zip(in_paths, save_paths))
         ]
-        
-        with multiprocessing.Pool(processes=num_workers) as pool:
+
+        with multiprocessing.Pool(processes=num_workers, maxtasksperchild=20) as pool:
             pool.starmap(process_single_file, tasks)
 
     else:
         print(">> Starting sequential processing...")
+        # Build model ONCE and reuse across subjects — avoids ~30 s/subject of
+        # rebuild + weight-reload overhead.
+        try:
+            shared_model = _build_stage_model(model_path, model_params)
+        except FileNotFoundError as exc:
+            print(f"Error: {exc}")
+            return
+        print(">> Model built once; reusing across all subjects.")
         for num, (path, save_path) in enumerate(zip(in_paths, save_paths)):
-            process_single_file(path, save_path, model_path, model_params, (num, len(in_paths)))
+            process_single_file(path, save_path, model_path, model_params, (num, len(in_paths)), model=shared_model)
     
     timer('* Finishing "caisr_stage"')
 


### PR DESCRIPTION
## Summary

- **Bug fix** — `caisr_arousal.py:set_output_paths` path-join bug that hid stage CSVs when `--output_csv_dir` lacked a trailing slash (write_path becoming `<dir>arousal/...` instead of `<dir>/arousal/...`).
- **Bug fix / OOM** — TF graph leak in `caisr_arousal.predict()`: every call rebuilds a new model and adds nodes to the default graph. After ~300 sequential subjects this hits ~32 GB. Adding `tf.keras.backend.clear_session()` at the start of `predict()` resets the graph each subject; verified stable across long array tasks.
- **Feature** — restore the older 6-EEG-channel arousal default (`f3-m2`, `f4-m1`, `c3-m2`, `c4-m1`, `o1-m2`, `o2-m1`) with a 6→2 fallback. Missing F3/F4/O1/O2 are dropped (no substitution from C3/C4), so `predict(EEG_chan=6)` raises and `process_single_arousal_file` falls back to `EEG_chan=2`.
- **Feature** — auto-detect uV vs V signal scale in `caisr_arousal.py` and `caisr_limb.py`. Trusts `f.attrs['unit_voltage']` when set, otherwise falls back to amplitude (99th-pct threshold of 30 in arousal, 0.5 in limb). Limb's `* 1e6` only fires when input is in V; uV inputs are no longer inflated by 1e6×.
- **Performance** — `caisr_stage.py`: build TF model **once** in the sequential dispatch path and reuse across subjects, saving ~30 s/subject of rebuild + weight reload. On a V100 this brings steady-state to ~25–50 s/subject.
- **Memory bound** — `caisr_stage.py`: cap `multiprocessing.Pool` workers at 12 (down from 24) and add `maxtasksperchild=20`. Observed: 24 workers OOMed at ~900 GB on a single node; 12 workers + worker recycling stays stable.
- **Docs** — new README sections **Running on GPU** (CUDA install matrix, env clones, compute-capability table, what works on Volta vs Ampere/Ada) and **Running at scale with SLURM job arrays** (sbatch template with input slicing via `SLURM_ARRAY_TASK_ID`, dependency-chained pipeline, `multiprocess=False` note for GPU array tasks).

## Test plan

- [x] Smoke test on real `.h5` (single subject) in CPU env (`caisr_arousal`, `caisr_limb`, `caisr_stage`)
- [x] Smoke test on real `.h5` in GPU env: `caisr_arousal_gpu` (TF 2.8 + cudatoolkit 11.2) on RTX 6000 Ada — 88 s/subj, 6-chn predict succeeded
- [x] Smoke test on V100 for `caisr_stage_gpu` (TF 1.15 + cudatoolkit 10.0) — 5 subjects in 2m 38s, ~40 s/subj steady-state with the model-reuse refactor
- [x] Run a 50-task SLURM array on a 43k-subject cohort end-to-end (stage GPU, arousal GPU, limb CPU, resp CPU, combine) using the README template

🤖 Generated with [Claude Code](https://claude.com/claude-code)